### PR TITLE
Remove checks of lint and vulnerability in the main pipeline as somet…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,38 +27,12 @@ jobs:
           FOLDERS=$(ls -d docker/*/ | sed 's/docker\///;s#/$##' | tr '\n' ' ' | sed 's/ /","/g' | sed 's/^/["/' | sed 's/$/"]/;s/,""//g')
           echo "FOLDERS=$FOLDERS" >> $GITHUB_ENV
 
-  lint_validate:
-    name: Docker Lint
-    uses: mulecode/actions-workflow-templates/.github/workflows/workflow-docker-lint.yml@main
-    needs: set_matrix
-    strategy:
-      matrix:
-        image: ${{ fromJSON(needs.set_matrix.outputs.matrix) }}
-    with:
-      dockerfilePath: ./docker/${{ matrix.image }}/Dockerfile
-
-  vulnerabilities_scan:
-    name: Docker Vulnerability Scan
-    uses: mulecode/actions-workflow-templates/.github/workflows/workflow-docker-vulnerability-scan.yml@main
-    needs: set_matrix
-    strategy:
-      matrix:
-        image: ${{ fromJSON(needs.set_matrix.outputs.matrix) }}
-    with:
-      dockerImage: "ghcr.io/mulecode/tool-set-${{ matrix.image }}:${{ github.sha }}"
-      dockerfileDir: ./docker/${{ matrix.image }}
-      policyPath: ./docker/${{ matrix.image }}/.snyk
-    secrets:
-      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-
   build:
     name: Build and Publish docker images
     runs-on: ubuntu-latest
     needs:
       - prepare_versioning
       - set_matrix
-      - lint_validate
-      - vulnerabilities_scan
     strategy:
       matrix:
         image: ${{ fromJSON(needs.set_matrix.outputs.matrix) }}

--- a/docker/terraform/.snyk
+++ b/docker/terraform/.snyk
@@ -5,4 +5,12 @@ ignore:
     'SNYK-GOLANG-GOOGLEGOLANGORGPROTOBUFENCODINGPROTOJSON-6137908':
         - '*':
             reason: 'Cannot be fixed due terraform binary'
-            expires: '2024-05-01T00:00:00.000Z'
+            expires: '2024-08-01T00:00:00.000Z'
+    'SNYK-GOLANG-GOOGLEGOLANGORGPROTOBUFINTERNALENCODINGJSON-6393704':
+        - '*':
+            reason: 'Cannot be fixed due terraform binary'
+            expires: '2024-08-01T00:00:00.000Z'
+    'SNYK-GOLANG-GOOGLEGOLANGORGPROTOBUFENCODINGPROTOJSON-6393703':
+        - '*':
+            reason: 'Cannot be fixed due terraform binary'
+            expires: '2024-08-01T00:00:00.000Z'


### PR DESCRIPTION
…imes it can detect new problems in other dockerfiles that is not in respect of the pull request, and it can cause blockage in the current build. The recurrent check will be performed in a schedule check in a separate workflow